### PR TITLE
PCA9536.h: Remove error directive for non-avr architecture

### DIFF
--- a/PCA9536.h
+++ b/PCA9536.h
@@ -122,10 +122,6 @@ __asm volatile ("nop");
 #ifndef PCA9536_h
 #define PCA9536_h
 
-#if !defined(ARDUINO_ARCH_AVR)
-#error “The PCA9536 library only supports AVR processors.”
-#endif
-
 #include <Arduino.h>
 #include "Wire.h"
 #include "utility/PCA9536_PString.h"


### PR DESCRIPTION
These lines cause this code to error for non-avr architectures, like arm. Since this is an Arduino library, I think its safe to assume the Wire library will exist for any arduino architecture, since Wire is part of the arduino cores. So I have removed these error directives below. 
```
#if !defined(ARDUINO_ARCH_AVR)
#error “The PCA9536 library only supports AVR processors.”
#endif
```